### PR TITLE
Add merchant ID for backend mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.0.27</version>
+    <version>2.0.28</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.27</version>
+    <version>2.0.28</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>

--- a/src/main/java/com/alipay/global/api/request/ams/pay/AlipayInquiryRefundRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/pay/AlipayInquiryRefundRequest.java
@@ -16,6 +16,11 @@ public class AlipayInquiryRefundRequest extends AlipayRequest<AlipayInquiryRefun
      */
     private String refundId;
 
+    /**
+     * The unique ID to identify a merchant account.
+     */
+    private String merchantAccountId;
+
     public String getRefundRequestId() {
         return refundRequestId;
     }
@@ -31,6 +36,10 @@ public class AlipayInquiryRefundRequest extends AlipayRequest<AlipayInquiryRefun
     public void setRefundId(String refundId) {
         this.refundId = refundId;
     }
+
+    public String getMerchantAccountId() { return merchantAccountId; }
+
+    public void setMerchantAccountId(String merchantAccountId) { this.merchantAccountId = merchantAccountId; }
 
     @Override
     public Class getResponseClass() {

--- a/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayCancelRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayCancelRequest.java
@@ -15,6 +15,11 @@ public class AlipayPayCancelRequest extends AlipayRequest<AlipayPayCancelRespons
      */
     private String paymentRequestId;
 
+    /**
+     * The unique ID to identify a merchant account.
+     */
+    private String merchantAccountId;
+
     public String getPaymentId() {
         return paymentId;
     }
@@ -30,6 +35,10 @@ public class AlipayPayCancelRequest extends AlipayRequest<AlipayPayCancelRespons
     public void setPaymentRequestId(String paymentRequestId) {
         this.paymentRequestId = paymentRequestId;
     }
+
+    public String getMerchantAccountId() { return merchantAccountId; }
+
+    public void setMerchantAccountId(String merchantAccountId) { this.merchantAccountId = merchantAccountId; }
 
     @Override
     public Class<AlipayPayCancelResponse> getResponseClass() {

--- a/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayConsultRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayConsultRequest.java
@@ -26,6 +26,10 @@ public class AlipayPayConsultRequest extends AlipayRequest<AlipayPayConsultRespo
     private Merchant        merchant;
     private List<String>    allowedPspRegions;
 
+    /**
+     * The unique ID to identify a merchant account.
+     */
+    private String merchantAccountId;
 
     public ProductCodeType getProductCode() {
         return productCode;
@@ -154,6 +158,10 @@ public class AlipayPayConsultRequest extends AlipayRequest<AlipayPayConsultRespo
     public void setAllowedPaymentMethodRegions(List<String> allowedPaymentMethodRegions) {
         this.allowedPaymentMethodRegions = allowedPaymentMethodRegions;
     }
+
+    public String getMerchantAccountId() { return merchantAccountId; }
+
+    public void setMerchantAccountId(String merchantAccountId) { this.merchantAccountId = merchantAccountId; }
 
     @Override
     public Class<AlipayPayConsultResponse> getResponseClass() {

--- a/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayQueryRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayQueryRequest.java
@@ -15,6 +15,11 @@ public class AlipayPayQueryRequest extends AlipayRequest<AlipayPayQueryResponse>
      */
     private String paymentId;
 
+    /**
+     * The unique ID to identify a merchant account.
+     */
+    private String merchantAccountId;
+
     public String getPaymentRequestId() {
         return paymentRequestId;
     }
@@ -30,6 +35,10 @@ public class AlipayPayQueryRequest extends AlipayRequest<AlipayPayQueryResponse>
     public void setPaymentId(String paymentId) {
         this.paymentId = paymentId;
     }
+
+    public String getMerchantAccountId() { return merchantAccountId; }
+
+    public void setMerchantAccountId(String merchantAccountId) { this.merchantAccountId = merchantAccountId; }
 
     @Override
     public Class<AlipayPayQueryResponse> getResponseClass() {

--- a/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/pay/AlipayPayRequest.java
@@ -91,6 +91,11 @@ public class AlipayPayRequest extends AlipayRequest<AlipayPayResponse> {
 
     private String                  extendInfo;
 
+    /**
+     * The unique ID to identify a merchant account.
+     */
+    private String merchantAccountId;
+
     public String getAppId() {
         return appId;
     }
@@ -250,6 +255,10 @@ public class AlipayPayRequest extends AlipayRequest<AlipayPayResponse> {
     public void setEnv(Env env) {
         this.env = env;
     }
+
+    public String getMerchantAccountId() { return merchantAccountId; }
+
+    public void setMerchantAccountId(String merchantAccountId) { this.merchantAccountId = merchantAccountId; }
 
     @Override
     public Class<AlipayPayResponse> getResponseClass() {


### PR DESCRIPTION
Problem:
Some Ali's API require merchant ID field to function correctly. Currently, this field is not provided when client app calls the API using SDK.

How we fix it:
Add merchant ID to the relevant classes in the SDK.