### PR TITLE
release: bump version to 2.1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.1.25</version>
+    <version>2.1.26</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.25</version>
+    <version>2.1.26</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>


### PR DESCRIPTION
Bump version to 2.1.26.

## 本次变更

- fix: restore TransactionTypeListEnum with full enum values synced to StatementTransactionType (6b5b402)
- [antom-sdk-automation] automated change (b695eb3)

## 文件改动

- `com/alipay/global/api/model/ams/Statement.java` (+1 -1)
- `com/alipay/global/api/model/ams/StatementTransactionType.java` (+99 -0, new)
- `com/alipay/global/api/model/ams/aba/AlipayInquiryStatementRequest.java` (+19 -4)

## Publish

- Maven Central 已上传到 Sonatype Central Portal (deploymentId: 457b9631-4a28-4c3f-a91e-b6cac9645995)
- 需要在 https://central.sonatype.com/publishing/deployments 手动 Publish
