### PR TITLE
release: bump version to 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.1.29</version>
+    <version>2.2.2</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>


### PR DESCRIPTION
## 版本 2.2.2

**核心变更（相对 2.2.1）**：JSON 引擎从 fastjson 迁移到 Jackson（PR #175），fastjson 依赖完全移除。

### 版本号变更
- `pom.xml`: 2.2.1 → 2.2.2
- `README.md`: 2.1.29 → 2.2.2（修正此前遗留的旧版本号）

### 发布验证
- ✅ 字节码扫描：0 个 class 引用 fastjson，59 个 class 使用 Jackson
- ✅ 产物 jar 运行时冒烟：pay/billing 序列化、嵌套/枚举/未知字段容忍反序列化全部通过
- ✅ billing 类 140 个完整
- ✅ 已上传 Maven Central（deploymentId: a513a208-3bc7-41a8-9484-b144713a250b）