### PR TITLE
feat: add SDK version to user agent (release 2.2.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>
@@ -99,6 +99,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -173,4 +179,3 @@
     </build>
 
 </project>
-

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION=$1
+if ! printf '%s\n' "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+  echo "Version must use stable SemVer format X.Y.Z: $VERSION" >&2
+  exit 1
+fi
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+python3 - "$ROOT_DIR" "$VERSION" <<'PY'
+import os
+import re
+import sys
+import tempfile
+
+root, version = sys.argv[1:3]
+
+
+def replace_once(relative_path, pattern, replacement):
+    path = os.path.join(root, relative_path)
+    with open(path, "r", encoding="utf-8", newline="") as source:
+        content = source.read()
+    updated, count = re.subn(pattern, replacement, content, count=1, flags=re.DOTALL)
+    if count != 1:
+        raise SystemExit("Expected exactly one version field in {}".format(relative_path))
+    directory = os.path.dirname(path)
+    descriptor, temporary = tempfile.mkstemp(dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as target:
+            target.write(updated)
+        os.chmod(temporary, os.stat(path).st_mode)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+replace_once(
+    "pom.xml",
+    r"(<artifactId>global-open-sdk-java</artifactId>\s*<packaging>jar</packaging>\s*<version>)[^<]+(</version>)",
+    r"\g<1>{}\g<2>".format(version),
+)
+replace_once(
+    "README.md",
+    r"(<artifactId>global-open-sdk-java</artifactId>\s*<version>)[^<]+(</version>)",
+    r"\g<1>{}\g<2>".format(version),
+)
+PY
+
+echo "Updated global-open-sdk-java to $VERSION"

--- a/src/main/java/com/alipay/global/api/BaseAlipayClient.java
+++ b/src/main/java/com/alipay/global/api/BaseAlipayClient.java
@@ -9,10 +9,12 @@ import com.alipay.global.api.request.AlipayRequest;
 import com.alipay.global.api.response.AlipayResponse;
 import com.alipay.global.api.tools.Constants;
 import com.alipay.global.api.tools.DateTool;
+import com.alipay.global.api.tools.SdkVersion;
 import com.alipay.global.api.tools.SignatureTool;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -110,6 +112,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
     if (customHeader != null && !customHeader.isEmpty()) {
       header.putAll(customHeader);
     }
+    applySdkUserAgent(header);
 
     String requestUrl = genRequestUrl(path);
     /** 向网关发起http请求(Make an HTTP request to the gateway) */
@@ -149,7 +152,13 @@ public abstract class BaseAlipayClient implements AlipayClient {
 
   private static final Set<String> RESERVED_HEADERS =
       new HashSet<>(
-          Arrays.asList("signature", "client-id", "request-time", "content-type", "agent-token"));
+          Arrays.asList(
+              "signature",
+              "client-id",
+              "request-time",
+              "content-type",
+              "agent-token",
+              "user-agent"));
 
   public <T extends AlipayResponse> T executeWithHeaders(
       AlipayRequest<T> alipayRequest, Map<String, String> extraHeaders) throws AlipayApiException {
@@ -191,6 +200,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
         }
       }
     }
+    applySdkUserAgent(header);
 
     String requestUrl = genRequestUrl(path);
     /** 向网关发起http请求(Make an HTTP request to the gateway) */
@@ -335,6 +345,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
       String requestTime, String clientId, Integer keyVersion, String signatureValue) {
     Map<String, String> header = new HashMap<String, String>();
     header.put(Constants.CONTENT_TYPE_HEADER, "application/json; charset=UTF-8");
+    header.put(Constants.USER_AGENT_HEADER, SdkVersion.getUserAgent());
     header.put(Constants.REQ_TIME_HEADER, requestTime);
     header.put(Constants.CLIENT_ID_HEADER, clientId);
     if (keyVersion == null) {
@@ -347,6 +358,17 @@ public abstract class BaseAlipayClient implements AlipayClient {
       header.put(Constants.AGENT_TOKEN_HEADER, agentToken);
     }
     return header;
+  }
+
+  private void applySdkUserAgent(Map<String, String> header) {
+    Iterator<Map.Entry<String, String>> iterator = header.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<String, String> entry = iterator.next();
+      if (Constants.USER_AGENT_HEADER.equalsIgnoreCase(entry.getKey())) {
+        iterator.remove();
+      }
+    }
+    header.put(Constants.USER_AGENT_HEADER, SdkVersion.getUserAgent());
   }
 
   public abstract Map<String, String> buildCustomHeader();

--- a/src/main/java/com/alipay/global/api/net/DefaultHttpRPC.java
+++ b/src/main/java/com/alipay/global/api/net/DefaultHttpRPC.java
@@ -4,6 +4,7 @@ import com.alipay.global.api.exception.AlipayApiException;
 import com.alipay.global.api.ssl.TrueHostnameVerifier;
 import com.alipay.global.api.ssl.X509TrustManagerImp;
 import com.alipay.global.api.tools.Constants;
+import com.alipay.global.api.tools.SdkVersion;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
@@ -126,7 +127,7 @@ public class DefaultHttpRPC {
     connHttps.setDoOutput(true);
     connHttps.setRequestProperty(
         Constants.ACCEPT_HEADER, "text/plain,text/xml,text/javascript,text/html");
-    connHttps.setRequestProperty(Constants.USER_AGENT_HEADER, "global-sdk-java");
+    connHttps.setRequestProperty(Constants.USER_AGENT_HEADER, SdkVersion.getUserAgent());
     connHttps.setRequestProperty(Constants.CONTENT_TYPE_HEADER, ctype);
     connHttps.setRequestProperty(Constants.CONNECTION_HEADER, "keep-alive");
     return connHttps;

--- a/src/main/java/com/alipay/global/api/tools/SdkVersion.java
+++ b/src/main/java/com/alipay/global/api/tools/SdkVersion.java
@@ -1,0 +1,46 @@
+package com.alipay.global.api.tools;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class SdkVersion {
+
+  private static final String SDK_NAME = "global-open-sdk-java";
+  private static final String VERSION = loadVersion();
+
+  private SdkVersion() {}
+
+  public static String getVersion() {
+    return VERSION;
+  }
+
+  public static String getUserAgent() {
+    return SDK_NAME + "/" + VERSION;
+  }
+
+  private static String loadVersion() {
+    InputStream input = SdkVersion.class.getResourceAsStream("sdk-version.properties");
+    if (input == null) {
+      return "unknown";
+    }
+
+    try {
+      Properties properties = new Properties();
+      properties.load(input);
+      String version = properties.getProperty("sdk.version");
+      if (version == null || version.trim().isEmpty() || version.contains("${")) {
+        return "unknown";
+      }
+      return version.trim();
+    } catch (IOException ignored) {
+      return "unknown";
+    } finally {
+      try {
+        input.close();
+      } catch (IOException ignored) {
+        // Nothing to do.
+      }
+    }
+  }
+}

--- a/src/main/resources/com/alipay/global/api/tools/sdk-version.properties
+++ b/src/main/resources/com/alipay/global/api/tools/sdk-version.properties
@@ -1,0 +1,1 @@
+sdk.version=${project.version}


### PR DESCRIPTION
## Summary
- Add unified SDK version identification via `User-Agent: global-open-sdk-java/{version}`
- Single version source: `pom.xml` project `<version>`, propagated to `sdk-version.properties` at build time
- Add `scripts/set-version.sh` as the unified version setter
- Bump version 2.2.3 → 2.2.4

Design doc: https://yuque.antfin.com/global-aquire/eibet3/ie54rtdm7fx24g6d