### PR TITLE
fix: 安全修复版本，升级最新的fastjson 1.2.84

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.83_noneautotype</version>
+            <version>1.2.84</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
## Summary
- 安全修复版本：fastjson `1.2.83_noneautotype` → `1.2.84`（官方修复 1.2.83 漏洞的版本；Maven Central 无 1.2.84_noneautotype 变体，标准版默认关闭 autoType）
- 版本号 2.2.4 → 2.2.5（经 `./scripts/set-version.sh 2.2.5`）

## Verification
- 本地 `mvn clean package` 通过，jar 内 `sdk.version=2.2.5`
- Maven Central deployment 已通过校验