### PR TITLE
release: bump version to 2.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>


### PR DESCRIPTION
## Summary
- bump Java SDK version from 2.2.6 to 2.2.7
- update the Maven dependency example in README

## Verification
- `mvn -B clean test package --no-transfer-progress`
- `mvn -B -P release verify --no-transfer-progress`
- Maven Central bundle uploaded and validated (deployment `89be0105-2002-4e44-8c08-6c4bb89f931e`)