### PR TITLE
release: bump version to 2.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.2.7</version>
+    <version>2.2.8</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.7</version>
+    <version>2.2.8</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>


### PR DESCRIPTION
## Summary
- bump Java SDK version from 2.2.7 to 2.2.8
- update the Maven dependency example in README
- prepare the accepted ABA card transaction and Meter uploadEvent HTTP/2 changes for release

## Verification
- `mvn clean test package`
- `mvn -P release verify`
- release artifacts and GPG signatures verified
- packaged SDK metadata and User-Agent version are `2.2.8`
- Git and JAR case-fold collision checks passed
- Java Meter uploadEvent live HTTP/2 regression returned `S / SUCCESS` with zero event errors
- Maven Central coordinate `2.2.8` is unoccupied