### PR TITLE
feat!: replace fastjson with Jackson in Java SDK 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ```
 Language：JAVA  
-JDK version：1.6+  
+JDK version：8+
 Copyright：Ant financial services group  
 ```
 
@@ -12,10 +12,38 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>2.2.10</version>
+    <version>3.0.0</version>
 </dependency>
 ```
    
+#### Upgrading to 3.0.0
+
+The SDK now uses Jackson for ordinary JSON requests, multipart JSON parts, and
+Meter HTTP/2 bodies. Its POM imports Jackson BOM `2.18.10`. An application's BOM
+can override these dependencies; check the effective dependency tree and keep
+Jackson modules aligned. Jackson 3 is not supported.
+
+Existing Client calls, model field types, and Java enum constants are retained.
+Generated AMS string enums write API wire values and accept both wire values and
+historical Java constant names on input; unknown input returns null, including
+direct calls to `fromValue`. In particular, `TEMPLATE`/`FILE` write
+`DISPUTE_EVIDENCE_TEMPLATE`/`DISPUTE_EVIDENCE_FILE`, and
+`PAYMENTCODE`/`ORDERCODE`/`ENTRYCODE` write `PaymentCode`/`OrderCode`/`EntryCode`.
+Authentication responses read both `isPassed` and historical `passed`, but write
+only `isPassed`.
+
+For custom JSON handling, use `com.alipay.global.api.tools.JsonUtil.toJson` and
+`JsonUtil.fromJson`. Object field order and complete JSON strings may change;
+assert JSON structure instead of string snapshots. The SDK no longer supplies
+fastjson transitively, so applications that still use it must manage that
+dependency themselves. The SDK's mapper is private and does not reuse an
+application's Spring ObjectMapper.
+
+Sign exactly the JSON body you send. For notifications, call
+`WebhookTool.checkSignature` with the original HTTP body **before** parsing it
+with `JsonUtil.fromJson`; do not reserialize a notification before verification.
+Meter HTTP/2 continues to use only `X-Session-Id`, as described below.
+
 #### 2 Main class file  
 ```java
 DefaultAlipayClient.java  
@@ -77,9 +105,9 @@ chinaExtraTransInfo.setBusinessType(BusinessType.HOTEL);
 chinaExtraTransInfo.setHotelName("hotelName");
 chinaExtraTransInfo.setCheckinTime("2020-06-26T10:00:00+08:00");
 chinaExtraTransInfo.setCheckoutTime("2020-06-26T10:00:00+08:00");
-JSONObject extendInfo = new JSONObject();
+Map<String, Object> extendInfo = new HashMap<String, Object>();
 extendInfo.put("chinaExtraTransInfo",chinaExtraTransInfo);
-order.setExtendInfo(extendInfo.toJSONString());
+order.setExtendInfo(JsonUtil.toJson(extendInfo));
 
 Merchant merchant = new Merchant();
 merchant.setMerchantMCC("testMcc");

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.10</version>
+    <version>3.0.0</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>
@@ -13,6 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.18.10</jackson.version>
     </properties>
 
     <licenses>
@@ -58,6 +59,18 @@
         </repository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -67,17 +80,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <version>1.2.84</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/src/main/java/com/alipay/global/api/BaseAlipayClient.java
+++ b/src/main/java/com/alipay/global/api/BaseAlipayClient.java
@@ -1,7 +1,5 @@
 package com.alipay.global.api;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alipay.global.api.exception.AlipayApiException;
 import com.alipay.global.api.model.Result;
 import com.alipay.global.api.net.HttpRpcResult;
@@ -9,6 +7,7 @@ import com.alipay.global.api.request.AlipayRequest;
 import com.alipay.global.api.response.AlipayResponse;
 import com.alipay.global.api.tools.Constants;
 import com.alipay.global.api.tools.DateTool;
+import com.alipay.global.api.tools.JsonUtil;
 import com.alipay.global.api.tools.SdkVersion;
 import com.alipay.global.api.tools.SignatureTool;
 import java.util.Arrays;
@@ -107,8 +106,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
     String path = alipayRequest.getPath();
     Integer keyVersion = alipayRequest.getKeyVersion();
     String reqTime = DateTool.getCurrentTimeMillis();
-    String reqBody =
-        JSON.toJSONString(alipayRequest, SerializerFeature.DisableCircularReferenceDetect);
+    String reqBody = JsonUtil.toJson(alipayRequest);
 
     /** 对内容加签(Sign the content) */
     String signValue = genSignValue(httpMethod, path, clientId, reqTime, reqBody);
@@ -135,7 +133,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
       throw new AlipayApiException("Response data error, rspBody:" + rspBody);
     }
     Class<T> responseClass = alipayRequest.getResponseClass();
-    T alipayResponse = JSON.parseObject(rspBody, responseClass);
+    T alipayResponse = JsonUtil.fromJson(rspBody, responseClass);
     Result result = alipayResponse.getResult();
     if (result == null) {
       throw new AlipayApiException("Response data error, result field is null, rspBody:" + rspBody);
@@ -189,8 +187,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
     String path = alipayRequest.getPath();
     Integer keyVersion = alipayRequest.getKeyVersion();
     String reqTime = DateTool.getCurrentTimeMillis();
-    String reqBody =
-        JSON.toJSONString(alipayRequest, SerializerFeature.DisableCircularReferenceDetect);
+    String reqBody = JsonUtil.toJson(alipayRequest);
 
     /** 对内容加签(Sign the content) */
     String signValue = genSignValue(httpMethod, path, clientId, reqTime, reqBody);
@@ -227,7 +224,7 @@ public abstract class BaseAlipayClient implements AlipayClient {
       throw new AlipayApiException("Response data error, rspBody:" + rspBody);
     }
     Class<T> responseClass = alipayRequest.getResponseClass();
-    T alipayResponse = JSON.parseObject(rspBody, responseClass);
+    T alipayResponse = JsonUtil.fromJson(rspBody, responseClass);
     Result result = alipayResponse.getResult();
     if (result == null) {
       throw new AlipayApiException("Response data error, result field is null, rspBody:" + rspBody);

--- a/src/main/java/com/alipay/global/api/FileUploadExecutor.java
+++ b/src/main/java/com/alipay/global/api/FileUploadExecutor.java
@@ -1,6 +1,5 @@
 package com.alipay.global.api;
 
-import com.alibaba.fastjson.JSON;
 import com.alipay.global.api.exception.AlipayApiException;
 import com.alipay.global.api.model.ResultStatusType;
 import com.alipay.global.api.net.HttpRpcResult;
@@ -9,6 +8,7 @@ import com.alipay.global.api.request.AlipayFileRequest;
 import com.alipay.global.api.response.AlipayResponse;
 import com.alipay.global.api.tools.Constants;
 import com.alipay.global.api.tools.DateTool;
+import com.alipay.global.api.tools.JsonUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -103,8 +103,8 @@ final class FileUploadExecutor {
 
     final T parsedResponse;
     try {
-      parsedResponse = JSON.parseObject(responseBody, operation.getResponseClass());
-    } catch (RuntimeException e) {
+      parsedResponse = JsonUtil.fromJson(responseBody, operation.getResponseClass());
+    } catch (AlipayApiException e) {
       throw new AlipayApiException("Response body is not valid JSON", e);
     }
     if (parsedResponse == null || parsedResponse.getResult() == null) {

--- a/src/main/java/com/alipay/global/api/FileUploadOperationRegistry.java
+++ b/src/main/java/com/alipay/global/api/FileUploadOperationRegistry.java
@@ -1,11 +1,11 @@
 package com.alipay.global.api;
 
-import com.alibaba.fastjson.JSON;
 import com.alipay.global.api.exception.AlipayApiException;
 import com.alipay.global.api.request.AlipayFileRequest;
 import com.alipay.global.api.request.ams.billing.AlipayProductUploadImageRequest;
 import com.alipay.global.api.response.AlipayResponse;
 import com.alipay.global.api.response.ams.billing.AlipayProductUploadImageResponse;
+import com.alipay.global.api.tools.JsonUtil;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,7 +69,7 @@ final class FileUploadOperationRegistry {
       Map<String, String> body = new LinkedHashMap<String, String>();
       body.put("productId", productRequest.getProductId());
       body.put("fileSha256", fileSha256);
-      return JSON.toJSONString(body);
+      return JsonUtil.toJson(body);
     }
   }
 }

--- a/src/main/java/com/alipay/global/api/SessionHttp2Executor.java
+++ b/src/main/java/com/alipay/global/api/SessionHttp2Executor.java
@@ -1,11 +1,10 @@
 package com.alipay.global.api;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alipay.global.api.exception.AlipayApiException;
 import com.alipay.global.api.model.Result;
 import com.alipay.global.api.request.AlipayRequest;
 import com.alipay.global.api.response.AlipayResponse;
+import com.alipay.global.api.tools.JsonUtil;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
@@ -19,15 +18,14 @@ final class SessionHttp2Executor {
       String gatewayUrl, AlipayRequest<T> request, Map<String, String> extraHeaders)
       throws AlipayApiException {
     String sessionId = validateAndGetSessionId(extraHeaders);
-    String requestBody =
-        JSON.toJSONString(request, SerializerFeature.DisableCircularReferenceDetect);
+    String requestBody = JsonUtil.toJson(request);
     String responseBody =
         Http2JsonTransport.post(gatewayUrl, request.getPath(), sessionId, requestBody);
 
     T response;
     try {
-      response = JSON.parseObject(responseBody, request.getResponseClass());
-    } catch (RuntimeException e) {
+      response = JsonUtil.fromJson(responseBody, request.getResponseClass());
+    } catch (AlipayApiException e) {
       throw new AlipayApiException("Failed to parse API response.", e);
     }
     Result result = response == null ? null : response.getResult();

--- a/src/main/java/com/alipay/global/api/example/CashierPayDemoCode.java
+++ b/src/main/java/com/alipay/global/api/example/CashierPayDemoCode.java
@@ -1,6 +1,5 @@
 package com.alipay.global.api.example;
 
-import com.alibaba.fastjson.JSONObject;
 import com.alipay.global.api.AlipayClient;
 import com.alipay.global.api.DefaultAlipayClient;
 import com.alipay.global.api.exception.AlipayApiException;
@@ -14,6 +13,7 @@ import com.alipay.global.api.response.ams.pay.AlipayPayConsultResponse;
 import com.alipay.global.api.response.ams.pay.AlipayPayQueryResponse;
 import com.alipay.global.api.response.ams.pay.AlipayPayResponse;
 import com.alipay.global.api.response.ams.pay.AlipayPaymentSessionResponse;
+import com.alipay.global.api.tools.JsonUtil;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -70,7 +70,7 @@ public class CashierPayDemoCode {
 
     try {
       alipayPayConsultResponse = CLIENT.execute(alipayPayConsultRequest);
-      System.out.println(JSONObject.toJSON(alipayPayConsultResponse));
+      System.out.println(JsonUtil.toJson(alipayPayConsultResponse));
     } catch (AlipayApiException e) {
       String errorMsg = e.getMessage();
       // handle error condition
@@ -98,7 +98,7 @@ public class CashierPayDemoCode {
     paymentMethodMetaData.put("expiryYear", "28");
     paymentMethodMetaData.put("tokenize", false);
     paymentMethodMetaData.put("cpf", "671.998.112-31");
-    JSONObject cardholderName = new JSONObject();
+    Map<String, String> cardholderName = new HashMap<String, String>();
     cardholderName.put("firstName", "Alan");
     cardholderName.put("lastName", "Wallex");
     paymentMethodMetaData.put("cardholderName", cardholderName);
@@ -145,7 +145,7 @@ public class CashierPayDemoCode {
     AlipayPayResponse alipayPayResponse = null;
     try {
       alipayPayResponse = CLIENT.execute(alipayPayRequest);
-      System.out.println(JSONObject.toJSON(alipayPayResponse));
+      System.out.println(JsonUtil.toJson(alipayPayResponse));
     } catch (AlipayApiException e) {
       String errorMsg = e.getMessage();
       // handle error condition

--- a/src/main/java/com/alipay/global/api/example/IsvPayDemo.java
+++ b/src/main/java/com/alipay/global/api/example/IsvPayDemo.java
@@ -1,6 +1,5 @@
 package com.alipay.global.api.example;
 
-import com.alibaba.fastjson.JSONObject;
 import com.alipay.global.api.AlipayClient;
 import com.alipay.global.api.DefaultAlipayClient;
 import com.alipay.global.api.exception.AlipayApiException;
@@ -10,6 +9,7 @@ import com.alipay.global.api.request.ams.pay.AlipayPayConsultRequest;
 import com.alipay.global.api.request.ams.pay.AlipayPayRequest;
 import com.alipay.global.api.response.ams.pay.AlipayPayConsultResponse;
 import com.alipay.global.api.response.ams.pay.AlipayPayResponse;
+import com.alipay.global.api.tools.JsonUtil;
 import java.util.UUID;
 
 public class IsvPayDemo {
@@ -64,7 +64,7 @@ public class IsvPayDemo {
 
     try {
       alipayPayConsultResponse = CLIENT.execute(alipayPayConsultRequest);
-      System.out.println(JSONObject.toJSON(alipayPayConsultResponse));
+      System.out.println(JsonUtil.toJson(alipayPayConsultResponse));
     } catch (AlipayApiException e) {
       String errorMsg = e.getMessage();
       e.printStackTrace();
@@ -118,7 +118,7 @@ public class IsvPayDemo {
     AlipayPayResponse alipayPayResponse = null;
     try {
       alipayPayResponse = CLIENT.execute(alipayPayRequest);
-      System.out.println(JSONObject.toJSON(alipayPayResponse));
+      System.out.println(JsonUtil.toJson(alipayPayResponse));
     } catch (AlipayApiException e) {
       String errorMsg = e.getMessage();
       System.out.println(errorMsg);

--- a/src/main/java/com/alipay/global/api/example/SubscriptionDemoCode.java
+++ b/src/main/java/com/alipay/global/api/example/SubscriptionDemoCode.java
@@ -1,6 +1,5 @@
 package com.alipay.global.api.example;
 
-import com.alibaba.fastjson.JSON;
 import com.alipay.global.api.AlipayClient;
 import com.alipay.global.api.DefaultAlipayClient;
 import com.alipay.global.api.exception.AlipayApiException;
@@ -8,6 +7,7 @@ import com.alipay.global.api.model.ams.*;
 import com.alipay.global.api.model.constants.EndPointConstants;
 import com.alipay.global.api.request.ams.subscription.AlipaySubscriptionCreateRequest;
 import com.alipay.global.api.response.ams.subscription.AlipaySubscriptionCreateResponse;
+import com.alipay.global.api.tools.JsonUtil;
 import java.util.UUID;
 
 public class SubscriptionDemoCode {
@@ -77,16 +77,14 @@ public class SubscriptionDemoCode {
 
     AlipaySubscriptionCreateResponse alipaySubscriptionCreateResponse = null;
 
-    System.out.println(JSON.toJSON(alipaySubscriptionCreateRequest));
-
     try {
+      System.out.println(JsonUtil.toJson(alipaySubscriptionCreateRequest));
       alipaySubscriptionCreateResponse = CLIENT.execute(alipaySubscriptionCreateRequest);
+      System.out.println(JsonUtil.toJson(alipaySubscriptionCreateResponse));
     } catch (AlipayApiException e) {
       String errorMsg = e.getMessage();
       System.out.println(e);
       // handle error condition
     }
-
-    System.out.println(JSON.toJSON(alipaySubscriptionCreateResponse));
   }
 }

--- a/src/main/java/com/alipay/global/api/example/legacy/PayNotifyListener.java
+++ b/src/main/java/com/alipay/global/api/example/legacy/PayNotifyListener.java
@@ -1,21 +1,44 @@
 package com.alipay.global.api.example.legacy;
 
-import com.alibaba.fastjson.JSON;
 import com.alipay.global.api.example.model.*;
+import com.alipay.global.api.exception.AlipayApiException;
 import com.alipay.global.api.model.Result;
 import com.alipay.global.api.model.ResultStatusType;
+import com.alipay.global.api.tools.JsonUtil;
+import com.alipay.global.api.tools.WebhookTool;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
 public class PayNotifyListener {
+  // Replace these values with the configured notification endpoint and credentials.
+  private static final String NOTIFY_PATH = "/payNotify";
+  private static final String CLIENT_ID = "";
+  private static final String ANTOM_PUBLIC_KEY = "";
 
   public void acceptNotify(HttpRequest request, HttpResponse response) {
 
-    InputStream inputStream = request.getInputStream();
-    String reqBody = read(inputStream);
-
-    PayNotifyRequest payNotifyRequest = JSON.parseObject(reqBody, PayNotifyRequest.class);
+    final PayNotifyRequest payNotifyRequest;
+    try {
+      String reqBody = read(request.getInputStream());
+      if (!WebhookTool.checkSignature(
+          NOTIFY_PATH,
+          "POST",
+          CLIENT_ID,
+          request.getHeader("Request-Time"),
+          request.getHeader("Signature"),
+          reqBody,
+          ANTOM_PUBLIC_KEY)) {
+        return;
+      }
+      payNotifyRequest = JsonUtil.fromJson(reqBody, PayNotifyRequest.class);
+    } catch (AlipayApiException | RuntimeException e) {
+      return;
+    }
+    if (payNotifyRequest == null || payNotifyRequest.getResultInfo() == null) {
+      return;
+    }
 
     if (!PaymentNotifyType.PAYMENT_RESULT.equals(payNotifyRequest.getNotifyType())) {
       return;
@@ -45,13 +68,22 @@ public class PayNotifyListener {
       payNotifyResponse.setResult(result);
       response
           .getOutputStream()
-          .write(JSON.toJSONString(payNotifyResponse).getBytes(Charset.forName("UTF-8")));
-    } catch (IOException e) {
+          .write(JsonUtil.toJson(payNotifyResponse).getBytes(Charset.forName("UTF-8")));
+    } catch (IOException | AlipayApiException e) {
     }
   }
 
   public String read(InputStream inputStream) {
-
-    return null;
+    try {
+      ByteArrayOutputStream body = new ByteArrayOutputStream();
+      byte[] buffer = new byte[4096];
+      int count;
+      while ((count = inputStream.read(buffer)) != -1) {
+        body.write(buffer, 0, count);
+      }
+      return new String(body.toByteArray(), Charset.forName("UTF-8"));
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to read notification body", e);
+    }
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/AbaCard.java
+++ b/src/main/java/com/alipay/global/api/model/ams/AbaCard.java
@@ -67,11 +67,11 @@ public class AbaCard {
     @JsonCreator
     public static CardStatusEnum fromValue(String value) {
       for (CardStatusEnum b : CardStatusEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 
@@ -109,11 +109,11 @@ public class AbaCard {
     @JsonCreator
     public static CardBrandEnum fromValue(String value) {
       for (CardBrandEnum b : CardBrandEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/model/ams/AccountHolderType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/AccountHolderType.java
@@ -41,10 +41,10 @@ public enum AccountHolderType {
   @JsonCreator
   public static AccountHolderType fromValue(String value) {
     for (AccountHolderType b : AccountHolderType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/AccountType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/AccountType.java
@@ -41,10 +41,10 @@ public enum AccountType {
   @JsonCreator
   public static AccountType fromValue(String value) {
     for (AccountType b : AccountType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/AssociationType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/AssociationType.java
@@ -49,10 +49,10 @@ public enum AssociationType {
   @JsonCreator
   public static AssociationType fromValue(String value) {
     for (AssociationType b : AssociationType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/AttachmentType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/AttachmentType.java
@@ -69,10 +69,10 @@ public enum AttachmentType {
   @JsonCreator
   public static AttachmentType fromValue(String value) {
     for (AttachmentType b : AttachmentType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CardBrand.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CardBrand.java
@@ -111,10 +111,10 @@ public enum CardBrand {
   @JsonCreator
   public static CardBrand fromValue(String value) {
     for (CardBrand b : CardBrand.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CardDetail.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CardDetail.java
@@ -63,11 +63,11 @@ public class CardDetail {
     @JsonCreator
     public static CardStatusEnum fromValue(String value) {
       for (CardStatusEnum b : CardStatusEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 
@@ -107,11 +107,11 @@ public class CardDetail {
     @JsonCreator
     public static CardBrandEnum fromValue(String value) {
       for (CardBrandEnum b : CardBrandEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/model/ams/CardPaymentMethodDetail.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CardPaymentMethodDetail.java
@@ -115,11 +115,11 @@ public class CardPaymentMethodDetail {
     @JsonCreator
     public static FundingEnum fromValue(String value) {
       for (FundingEnum b : FundingEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/model/ams/CardTransactionEventFilterType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CardTransactionEventFilterType.java
@@ -49,10 +49,10 @@ public enum CardTransactionEventFilterType {
   @JsonCreator
   public static CardTransactionEventFilterType fromValue(String value) {
     for (CardTransactionEventFilterType b : CardTransactionEventFilterType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CardTransactionStatusFilterType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CardTransactionStatusFilterType.java
@@ -43,10 +43,10 @@ public enum CardTransactionStatusFilterType {
   @JsonCreator
   public static CardTransactionStatusFilterType fromValue(String value) {
     for (CardTransactionStatusFilterType b : CardTransactionStatusFilterType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CertificateType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CertificateType.java
@@ -51,10 +51,10 @@ public enum CertificateType {
   @JsonCreator
   public static CertificateType fromValue(String value) {
     for (CertificateType b : CertificateType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ChallengeTriggerSourceType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ChallengeTriggerSourceType.java
@@ -41,10 +41,10 @@ public enum ChallengeTriggerSourceType {
   @JsonCreator
   public static ChallengeTriggerSourceType fromValue(String value) {
     for (ChallengeTriggerSourceType b : ChallengeTriggerSourceType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ChallengeType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ChallengeType.java
@@ -43,10 +43,10 @@ public enum ChallengeType {
   @JsonCreator
   public static ChallengeType fromValue(String value) {
     for (ChallengeType b : ChallengeType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ClassType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ClassType.java
@@ -43,10 +43,10 @@ public enum ClassType {
   @JsonCreator
   public static ClassType fromValue(String value) {
     for (ClassType b : ClassType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CodeValueType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CodeValueType.java
@@ -41,10 +41,10 @@ public enum CodeValueType {
   @JsonCreator
   public static CodeValueType fromValue(String value) {
     for (CodeValueType b : CodeValueType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CompanyType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CompanyType.java
@@ -61,10 +61,10 @@ public enum CompanyType {
   @JsonCreator
   public static CompanyType fromValue(String value) {
     for (CompanyType b : CompanyType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CompanyUnitType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CompanyUnitType.java
@@ -41,10 +41,10 @@ public enum CompanyUnitType {
   @JsonCreator
   public static CompanyUnitType fromValue(String value) {
     for (CompanyUnitType b : CompanyUnitType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ContactType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ContactType.java
@@ -43,10 +43,10 @@ public enum ContactType {
   @JsonCreator
   public static ContactType fromValue(String value) {
     for (ContactType b : ContactType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CreditPayFeeType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CreditPayFeeType.java
@@ -39,10 +39,10 @@ public enum CreditPayFeeType {
   @JsonCreator
   public static CreditPayFeeType fromValue(String value) {
     for (CreditPayFeeType b : CreditPayFeeType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/CustomerBelongsTo.java
+++ b/src/main/java/com/alipay/global/api/model/ams/CustomerBelongsTo.java
@@ -97,10 +97,10 @@ public enum CustomerBelongsTo {
   @JsonCreator
   public static CustomerBelongsTo fromValue(String value) {
     for (CustomerBelongsTo b : CustomerBelongsTo.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/DeclarationBizSceneType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/DeclarationBizSceneType.java
@@ -41,10 +41,10 @@ public enum DeclarationBizSceneType {
   @JsonCreator
   public static DeclarationBizSceneType fromValue(String value) {
     for (DeclarationBizSceneType b : DeclarationBizSceneType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/DisplayType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/DisplayType.java
@@ -47,10 +47,10 @@ public enum DisplayType {
   @JsonCreator
   public static DisplayType fromValue(String value) {
     for (DisplayType b : DisplayType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/DisputeEvidenceFormatType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/DisputeEvidenceFormatType.java
@@ -41,10 +41,10 @@ public enum DisputeEvidenceFormatType {
   @JsonCreator
   public static DisputeEvidenceFormatType fromValue(String value) {
     for (DisputeEvidenceFormatType b : DisputeEvidenceFormatType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/DisputeEvidenceType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/DisputeEvidenceType.java
@@ -41,10 +41,10 @@ public enum DisputeEvidenceType {
   @JsonCreator
   public static DisputeEvidenceType fromValue(String value) {
     for (DisputeEvidenceType b : DisputeEvidenceType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/FundingType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/FundingType.java
@@ -47,10 +47,10 @@ public enum FundingType {
   @JsonCreator
   public static FundingType fromValue(String value) {
     for (FundingType b : FundingType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/FundsType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/FundsType.java
@@ -39,10 +39,10 @@ public enum FundsType {
   @JsonCreator
   public static FundsType fromValue(String value) {
     for (FundsType b : FundsType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/GrantType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/GrantType.java
@@ -41,10 +41,10 @@ public enum GrantType {
   @JsonCreator
   public static GrantType fromValue(String value) {
     for (GrantType b : GrantType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/InStorePaymentScenario.java
+++ b/src/main/java/com/alipay/global/api/model/ams/InStorePaymentScenario.java
@@ -43,10 +43,10 @@ public enum InStorePaymentScenario {
   @JsonCreator
   public static InStorePaymentScenario fromValue(String value) {
     for (InStorePaymentScenario b : InStorePaymentScenario.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/InteractionType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/InteractionType.java
@@ -51,10 +51,10 @@ public enum InteractionType {
   @JsonCreator
   public static InteractionType fromValue(String value) {
     for (InteractionType b : InteractionType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/LegalEntityType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/LegalEntityType.java
@@ -41,10 +41,10 @@ public enum LegalEntityType {
   @JsonCreator
   public static LegalEntityType fromValue(String value) {
     for (LegalEntityType b : LegalEntityType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/MerchantType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/MerchantType.java
@@ -41,10 +41,10 @@ public enum MerchantType {
   @JsonCreator
   public static MerchantType fromValue(String value) {
     for (MerchantType b : MerchantType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/OsType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/OsType.java
@@ -41,10 +41,10 @@ public enum OsType {
   @JsonCreator
   public static OsType fromValue(String value) {
     for (OsType b : OsType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PassengerIdType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PassengerIdType.java
@@ -55,10 +55,10 @@ public enum PassengerIdType {
   @JsonCreator
   public static PassengerIdType fromValue(String value) {
     for (PassengerIdType b : PassengerIdType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PaymentMethodCategoryType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PaymentMethodCategoryType.java
@@ -53,10 +53,10 @@ public enum PaymentMethodCategoryType {
   @JsonCreator
   public static PaymentMethodCategoryType fromValue(String value) {
     for (PaymentMethodCategoryType b : PaymentMethodCategoryType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PaymentMethodDetailType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PaymentMethodDetailType.java
@@ -45,10 +45,10 @@ public enum PaymentMethodDetailType {
   @JsonCreator
   public static PaymentMethodDetailType fromValue(String value) {
     for (PaymentMethodDetailType b : PaymentMethodDetailType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PaymentMethodScope.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PaymentMethodScope.java
@@ -41,10 +41,10 @@ public enum PaymentMethodScope {
   @JsonCreator
   public static PaymentMethodScope fromValue(String value) {
     for (PaymentMethodScope b : PaymentMethodScope.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PaymentStatus.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PaymentStatus.java
@@ -44,10 +44,10 @@ public enum PaymentStatus {
   @JsonCreator
   public static PaymentStatus fromValue(String value) {
     for (PaymentStatus b : PaymentStatus.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PeriodType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PeriodType.java
@@ -55,10 +55,10 @@ public enum PeriodType {
   @JsonCreator
   public static PeriodType fromValue(String value) {
     for (PeriodType b : PeriodType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PresentmentMode.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PresentmentMode.java
@@ -43,10 +43,10 @@ public enum PresentmentMode {
   @JsonCreator
   public static PresentmentMode fromValue(String value) {
     for (PresentmentMode b : PresentmentMode.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ProductCodeType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ProductCodeType.java
@@ -43,10 +43,10 @@ public enum ProductCodeType {
   @JsonCreator
   public static ProductCodeType fromValue(String value) {
     for (ProductCodeType b : ProductCodeType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/PromotionType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/PromotionType.java
@@ -41,10 +41,10 @@ public enum PromotionType {
   @JsonCreator
   public static PromotionType fromValue(String value) {
     for (PromotionType b : PromotionType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ProrationSettings.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ProrationSettings.java
@@ -52,11 +52,11 @@ public class ProrationSettings {
     @JsonCreator
     public static ProrationModeEnum fromValue(String value) {
       for (ProrationModeEnum b : ProrationModeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/model/ams/RateType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/RateType.java
@@ -43,10 +43,10 @@ public enum RateType {
   @JsonCreator
   public static RateType fromValue(String value) {
     for (RateType b : RateType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/RefundFromType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/RefundFromType.java
@@ -43,10 +43,10 @@ public enum RefundFromType {
   @JsonCreator
   public static RefundFromType fromValue(String value) {
     for (RefundFromType b : RefundFromType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/RefundPreference.java
+++ b/src/main/java/com/alipay/global/api/model/ams/RefundPreference.java
@@ -56,11 +56,11 @@ public class RefundPreference {
     @JsonCreator
     public static PreferenceTypeEnum fromValue(String value) {
       for (PreferenceTypeEnum b : PreferenceTypeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/model/ams/ReleaseType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ReleaseType.java
@@ -41,10 +41,10 @@ public enum ReleaseType {
   @JsonCreator
   public static ReleaseType fromValue(String value) {
     for (ReleaseType b : ReleaseType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ResultStatusType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ResultStatusType.java
@@ -43,10 +43,10 @@ public enum ResultStatusType {
   @JsonCreator
   public static ResultStatusType fromValue(String value) {
     for (ResultStatusType b : ResultStatusType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/RuleStatus.java
+++ b/src/main/java/com/alipay/global/api/model/ams/RuleStatus.java
@@ -44,10 +44,10 @@ public enum RuleStatus {
   @JsonCreator
   public static RuleStatus fromValue(String value) {
     for (RuleStatus b : RuleStatus.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/ScopeType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/ScopeType.java
@@ -51,10 +51,10 @@ public enum ScopeType {
   @JsonCreator
   public static ScopeType fromValue(String value) {
     for (ScopeType b : ScopeType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/SettleToType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/SettleToType.java
@@ -41,10 +41,10 @@ public enum SettleToType {
   @JsonCreator
   public static SettleToType fromValue(String value) {
     for (SettleToType b : SettleToType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/Statement.java
+++ b/src/main/java/com/alipay/global/api/model/ams/Statement.java
@@ -105,11 +105,11 @@ public class Statement {
     @JsonCreator
     public static TransactionTypeEnum fromValue(String value) {
       for (TransactionTypeEnum b : TransactionTypeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/model/ams/SubscriptionStatus.java
+++ b/src/main/java/com/alipay/global/api/model/ams/SubscriptionStatus.java
@@ -47,10 +47,10 @@ public enum SubscriptionStatus {
   @JsonCreator
   public static SubscriptionStatus fromValue(String value) {
     for (SubscriptionStatus b : SubscriptionStatus.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/TakeType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/TakeType.java
@@ -39,10 +39,10 @@ public enum TakeType {
   @JsonCreator
   public static TakeType fromValue(String value) {
     for (TakeType b : TakeType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/TerminalType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/TerminalType.java
@@ -45,10 +45,10 @@ public enum TerminalType {
   @JsonCreator
   public static TerminalType fromValue(String value) {
     for (TerminalType b : TerminalType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/TransactionStatusType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/TransactionStatusType.java
@@ -47,10 +47,10 @@ public enum TransactionStatusType {
   @JsonCreator
   public static TransactionStatusType fromValue(String value) {
     for (TransactionStatusType b : TransactionStatusType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/TransactionType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/TransactionType.java
@@ -51,10 +51,10 @@ public enum TransactionType {
   @JsonCreator
   public static TransactionType fromValue(String value) {
     for (TransactionType b : TransactionType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/model/ams/TransitType.java
+++ b/src/main/java/com/alipay/global/api/model/ams/TransitType.java
@@ -45,10 +45,10 @@ public enum TransitType {
   @JsonCreator
   public static TransitType fromValue(String value) {
     for (TransitType b : TransitType.values()) {
-      if (b.value.equals(value)) {
+      if (b.value.equals(value) || b.name().equals(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/src/main/java/com/alipay/global/api/request/AlipayRequest.java
+++ b/src/main/java/com/alipay/global/api/request/AlipayRequest.java
@@ -1,27 +1,22 @@
 package com.alipay.global.api.request;
 
-import com.alibaba.fastjson.annotation.JSONField;
 import com.alipay.global.api.net.HttpMethod;
 import com.alipay.global.api.response.AlipayResponse;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 @Data
 public abstract class AlipayRequest<T extends AlipayResponse> {
   /** client id */
-  @JSONField(serialize = false)
-  private String clientId;
+  @JsonIgnore private String clientId;
 
-  @JSONField(serialize = false)
-  private String path;
+  @JsonIgnore private String path;
 
-  @JSONField(serialize = false)
-  private Integer keyVersion;
+  @JsonIgnore private Integer keyVersion;
 
-  @JSONField(serialize = false)
-  private Class<T> responseClass;
+  @JsonIgnore private Class<T> responseClass;
 
-  @JSONField(serialize = false)
-  private String httpMethod = HttpMethod.POST.name();
+  @JsonIgnore private String httpMethod = HttpMethod.POST.name();
 
   /**
    * 是否使用沙箱url
@@ -37,5 +32,6 @@ public abstract class AlipayRequest<T extends AlipayResponse> {
    *
    * @return 响应类型
    */
+  @JsonIgnore
   public abstract Class<T> getResponseClass();
 }

--- a/src/main/java/com/alipay/global/api/request/ams/aba/AlipayInquireCardRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/aba/AlipayInquireCardRequest.java
@@ -64,11 +64,11 @@ public class AlipayInquireCardRequest extends AlipayRequest<AlipayInquireCardRes
     @JsonCreator
     public static CardStatusEnum fromValue(String value) {
       for (CardStatusEnum b : CardStatusEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/request/ams/aba/AlipayInquiryStatementRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/aba/AlipayInquiryStatementRequest.java
@@ -120,11 +120,11 @@ public class AlipayInquiryStatementRequest extends AlipayRequest<AlipayInquirySt
     @JsonCreator
     public static TransactionTypeListEnum fromValue(String value) {
       for (TransactionTypeListEnum b : TransactionTypeListEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/request/ams/aba/AlipayUpdateCardStatusRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/aba/AlipayUpdateCardStatusRequest.java
@@ -63,11 +63,11 @@ public class AlipayUpdateCardStatusRequest extends AlipayRequest<AlipayUpdateCar
     @JsonCreator
     public static OperateTypeEnum fromValue(String value) {
       for (OperateTypeEnum b : OperateTypeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/request/ams/billing/AlipayInvoiceReviseRequest.java
+++ b/src/main/java/com/alipay/global/api/request/ams/billing/AlipayInvoiceReviseRequest.java
@@ -12,7 +12,6 @@
 
 package com.alipay.global.api.request.ams.billing;
 
-import com.alibaba.fastjson.annotation.JSONField;
 import com.alipay.global.api.model.ams.*;
 import com.alipay.global.api.request.AlipayRequest;
 import com.alipay.global.api.response.ams.billing.AlipayInvoiceReviseResponse;
@@ -45,7 +44,6 @@ public class AlipayInvoiceReviseRequest extends AlipayRequest<AlipayInvoiceRevis
    * (atomic); &#x60;false&#x60; &#x3D; clone original without voiding (original untouched). Cannot
    * be null.
    */
-  @JSONField(name = "void")
   @JsonProperty("void")
   private Boolean voidValue;
 

--- a/src/main/java/com/alipay/global/api/response/ams/aba/AlipayInquireCardDetailResponse.java
+++ b/src/main/java/com/alipay/global/api/response/ams/aba/AlipayInquireCardDetailResponse.java
@@ -63,11 +63,11 @@ public class AlipayInquireCardDetailResponse extends AlipayResponse {
     @JsonCreator
     public static CardStatusEnum fromValue(String value) {
       for (CardStatusEnum b : CardStatusEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 
@@ -107,11 +107,11 @@ public class AlipayInquireCardDetailResponse extends AlipayResponse {
     @JsonCreator
     public static CardBrandEnum fromValue(String value) {
       for (CardBrandEnum b : CardBrandEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equals(value) || b.name().equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
   }
 

--- a/src/main/java/com/alipay/global/api/response/ams/users/AlipayVerifyAuthenticationResponse.java
+++ b/src/main/java/com/alipay/global/api/response/ams/users/AlipayVerifyAuthenticationResponse.java
@@ -1,6 +1,8 @@
 package com.alipay.global.api.response.ams.users;
 
 import com.alipay.global.api.response.AlipayResponse;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -9,4 +11,15 @@ import lombok.EqualsAndHashCode;
 public class AlipayVerifyAuthenticationResponse extends AlipayResponse {
 
   private boolean isPassed;
+
+  @JsonProperty("isPassed")
+  public boolean isPassed() {
+    return isPassed;
+  }
+
+  @JsonProperty("isPassed")
+  @JsonAlias("passed")
+  public void setPassed(boolean passed) {
+    this.isPassed = passed;
+  }
 }

--- a/src/main/java/com/alipay/global/api/tools/JsonUtil.java
+++ b/src/main/java/com/alipay/global/api/tools/JsonUtil.java
@@ -1,0 +1,60 @@
+package com.alipay.global.api.tools;
+
+import com.alipay.global.api.exception.AlipayApiException;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/** The SDK's JSON wire format, independent of application ObjectMapper configuration. */
+public final class JsonUtil {
+  private static final ObjectMapper MAPPER = createMapper();
+
+  private JsonUtil() {}
+
+  private static ObjectMapper createMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+    mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    return mapper;
+  }
+
+  /**
+   * Serializes a value using the SDK's API field and enum mappings.
+   *
+   * @param value the value to serialize
+   * @return the JSON body; a null value produces JSON null
+   * @throws AlipayApiException when the value cannot be serialized
+   */
+  public static String toJson(Object value) throws AlipayApiException {
+    try {
+      return MAPPER.writeValueAsString(value);
+    } catch (JsonProcessingException | IllegalArgumentException e) {
+      throw new AlipayApiException("Failed to serialize JSON.", e);
+    }
+  }
+
+  /**
+   * Parses JSON into a caller-selected type. Unknown properties are ignored.
+   *
+   * @param json the JSON body
+   * @param type the expected Java type
+   * @param <T> the expected result type
+   * @return the parsed value, or null for a null or empty body
+   * @throws AlipayApiException when JSON cannot be bound to the expected type
+   */
+  public static <T> T fromJson(String json, Class<T> type) throws AlipayApiException {
+    if (json == null || json.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      return MAPPER.readValue(json, type);
+    } catch (JsonProcessingException | IllegalArgumentException e) {
+      throw new AlipayApiException("Failed to parse JSON.", e);
+    }
+  }
+}

--- a/templates/libraries/jersey3/ENUM_TEMPLATE_NOTES.md
+++ b/templates/libraries/jersey3/ENUM_TEMPLATE_NOTES.md
@@ -1,0 +1,13 @@
+# Enum Template Ownership
+
+`modelEnum.mustache` and `modelInnerEnum.mustache` originate from the Java templates
+in OpenAPI Generator 6.0.1, matching the existing Automation toolchain.
+
+The local override preserves enum names, values, annotations and non-string enum
+behavior. String enums accept both API wire values and Java constant names on
+input, return null for unknown input, and serialize only their `@JsonValue` value.
+Maintain both standalone and inner-enum templates when changing this contract.
+
+Do not edit generated enums directly. Regenerate using the existing Automation
+tasks and the same formatting step used by the GitHub workflow. Reproduction and
+compatibility checks are maintained in integration-loop.

--- a/templates/libraries/jersey3/model.mustache
+++ b/templates/libraries/jersey3/model.mustache
@@ -7,13 +7,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
 import lombok.*;
-{{#models}}
-{{#model}}
-{{#vendorExtensions.x-has-wire-name}}
-import com.alibaba.fastjson.annotation.JSONField;
-{{/vendorExtensions.x-has-wire-name}}
-{{/model}}
-{{/models}}
 import com.alipay.global.api.request.AlipayRequest;
 import com.alipay.global.api.response.AlipayResponse;
 import com.alipay.global.api.model.ams.*;

--- a/templates/libraries/jersey3/modelEnum.mustache
+++ b/templates/libraries/jersey3/modelEnum.mustache
@@ -1,0 +1,100 @@
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
+{{#gson}}
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+{{/gson}}
+
+/**
+ * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+ */
+{{#gson}}
+@JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+{{#jsonb}}
+@JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
+@JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
+{{/jsonb}}
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+  /**
+   * {{.}}
+   */
+     {{/enumDescription}}
+  {{#withXml}}
+  @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  {{/withXml}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private {{{dataType}}} value;
+
+  {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+{{#jackson}}
+  @JsonValue
+{{/jackson}}
+  public {{{dataType}}} getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+{{#jackson}}
+  @JsonCreator
+{{/jackson}}
+  public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+    for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (b.value.equals(value){{#isString}} || b.name().equals(value){{/isString}}) {
+        return b;
+      }
+    }
+    {{#isString}}return null;{{/isString}}{{^isString}}{{#isNullable}}return null;{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}{{#allowableValues}}{{#enumVars}}{{#-last}}return {{{name}}};{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/enumUnknownDefaultCase}}{{/isNullable}}{{/isString}}
+  }
+{{#gson}}
+
+  public static class Adapter extends TypeAdapter<{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}> {
+    @Override
+    public void write(final JsonWriter jsonWriter, final {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} enumeration) throws IOException {
+      jsonWriter.value(enumeration.getValue());
+    }
+
+    @Override
+    public {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+      {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}next{{{dataType}}}(){{/isInteger}}{{/isNumber}};
+      return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+    }
+  }
+{{/gson}}
+{{#jsonb}}
+  public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
+    @Override
+    public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+      for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (String.valueOf(b.value).equals(parser.getString())) {
+          return b;
+        }
+      }
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");{{/useNullForUnknownEnumValue}}
+    }
+  }
+
+  public static final class Serializer implements JsonbSerializer<{{datatypeWithEnum}}> {
+    @Override
+    public void serialize({{datatypeWithEnum}} obj, JsonGenerator generator, SerializationContext ctx) {
+      generator.write(obj.value);
+    }
+  }
+{{/jsonb}}
+}

--- a/templates/libraries/jersey3/modelInnerEnum.mustache
+++ b/templates/libraries/jersey3/modelInnerEnum.mustache
@@ -1,0 +1,95 @@
+  /**
+   * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+   */
+{{#gson}}
+  @JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+{{#jsonb}}
+  @JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
+  @JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
+{{/jsonb}}
+{{#withXml}}
+  @XmlType(name="{{datatypeWithEnum}}")
+  @XmlEnum({{dataType}}.class)
+{{/withXml}}
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+    {{#allowableValues}}
+      {{#enumVars}}
+    {{#enumDescription}}
+    /**
+     * {{.}}
+     */
+    {{/enumDescription}}
+    {{#withXml}}
+    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    {{/withXml}}
+    {{{name}}}({{{value}}}){{^-last}},
+    {{/-last}}{{#-last}};{{/-last}}
+      {{/enumVars}}
+    {{/allowableValues}}
+
+    private {{{dataType}}} value;
+
+    {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+      this.value = value;
+    }
+
+{{#jackson}}
+    @JsonValue
+{{/jackson}}
+    public {{{dataType}}} getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+{{#jackson}}
+    @JsonCreator
+{{/jackson}}
+    public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+      for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (b.value.equals(value){{#isString}} || b.name().equals(value){{/isString}}) {
+          return b;
+        }
+      }
+      {{#isString}}return null;{{/isString}}{{^isString}}{{#isNullable}}return null;{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}{{#allowableValues}}{{#enumVars}}{{#-last}}return {{{name}}};{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/enumUnknownDefaultCase}}{{/isNullable}}{{/isString}}
+    }
+{{#gson}}
+
+    public static class Adapter extends TypeAdapter<{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+        {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isFloat}}(float){{/isFloat}} jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}{{#isFloat}}nextDouble{{/isFloat}}{{^isFloat}}next{{{dataType}}}{{/isFloat}}(){{/isInteger}}{{/isNumber}};
+        return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+      }
+    }
+{{/gson}}
+{{#jsonb}}
+    public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
+      @Override
+      public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+        for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+          if (String.valueOf(b.value).equals(parser.getString())) {
+            return b;
+          }
+        }
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");{{/useNullForUnknownEnumValue}}
+      }
+    }
+
+    public static final class Serializer implements JsonbSerializer<{{datatypeWithEnum}}> {
+      @Override
+      public void serialize({{datatypeWithEnum}} obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write(obj.value);
+      }
+    }
+{{/jsonb}}
+  }

--- a/templates/libraries/jersey3/pojo.mustache
+++ b/templates/libraries/jersey3/pojo.mustache
@@ -45,7 +45,6 @@ public class {{classname}} {{#lambdas.parent}}{{classname}} 1 {{/lambdas.parent}
                         */
                     {{/description}}
                     {{#vendorExtensions.x-wire-name}}
-                    @JSONField(name = "{{vendorExtensions.x-wire-name}}")
                     @JsonProperty("{{vendorExtensions.x-wire-name}}")
                     {{/vendorExtensions.x-wire-name}}
                     private {{#lambdas.specificScopeType}} {{name}}|{{{datatypeWithEnum}}}{{/lambdas.specificScopeType}}  {{#lambdas.camelCase}} {{name}} {{/lambdas.camelCase}};
@@ -61,7 +60,6 @@ public class {{classname}} {{#lambdas.parent}}{{classname}} 1 {{/lambdas.parent}
                         */
                     {{/description}}
                     {{#vendorExtensions.x-wire-name}}
-                    @JSONField(name = "{{vendorExtensions.x-wire-name}}")
                     @JsonProperty("{{vendorExtensions.x-wire-name}}")
                     {{/vendorExtensions.x-wire-name}}
                     private {{#lambdas.specificScopeType}} {{name}}|{{{datatypeWithEnum}}}{{/lambdas.specificScopeType}}  {{#lambdas.camelCase}} {{name}} {{/lambdas.camelCase}};


### PR DESCRIPTION
## Summary

- remove the Java SDK runtime dependency and source usage of fastjson
- use Jackson 2.18.10 as the single JSON implementation
- preserve existing Java model fields, field types, enum constant names and client call patterns
- serialize enums with API wire values and accept both wire values and historical Java enum names on input
- update SDK-owned generation templates so later OpenAPI generation preserves the migration
- set the SDK version to 3.0.0 because the dependency and observable JSON implementation change are a major-version boundary

## Compatibility

Standard AlipayClient usage remains source-compatible. The generated-code A/B/C check found identical public API signatures across 906 generated classes. Customers that directly depend on fastjson transitively, directly serialize SDK models with fastjson, or assert complete JSON strings must review the 3.0.0 migration notes.

The SDK defaults to Jackson 2.18.10. Compatibility contracts also cover Spring Boot-managed Jackson 2.12.7.1, 2.13.5, 2.15.4 and 2.21.4; those checks validate the documented JSON surface and do not endorse old versions as security recommendations.

## Verification

- JDK 8 mvn clean test package: passed
- JAR, sources JAR and Javadoc JAR: built successfully
- dependency tree: Jackson core/databind/annotations 2.18.10; no fastjson
- source/template scan: no fastjson references
- Automation A/B/C run: 62 expected generated changes, candidate regeneration produced 0 drift, public API signatures identical
- GitHub evidence: https://github.com/TeaDrinkerPlus/antom-adk-automation/actions/runs/33354721866
- integration-loop compatibility, transport/signing, artifact, old-Jackson matrix and sandbox chains: passed

## Review and release controls

This PR requires manual review and manual merge. Do not enable auto-merge.

This PR does not authorize publishing 3.0.0. After merge, the exact merged master commit must be checked out in a fresh directory, rebuilt and revalidated before a separate publication confirmation.

The existing dependency security scan remains review-required for historical non-Jackson dependencies that were explicitly excluded from this change. A responsible owner must record the release exception before publication.