### PR TITLE
chore(release): prepare Java SDK 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-java
 <dependency>
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
    

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.alipay.global.sdk</groupId>
     <artifactId>global-open-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <name>global-open-sdk-java</name>
     <url>https://github.com/alipay/global-open-sdk-java</url>
     <description>


### PR DESCRIPTION
## Summary
- Bump global-open-sdk-java from 3.0.0 to 3.0.1.
- Prepare the merged Payment Hold/Release API updates for publication.

## Validation
- Post-merge release regression: Offline 30/30 and Sandbox 5/5 passed.
- mvn clean test package passed.
- Maven release verify and GPG signature verification passed.
- Main, sources, Javadoc, and POM artifacts were inspected.
- Git and JAR case-collision checks passed.

## Scope
This PR changes only pom.xml and the README version example.